### PR TITLE
Fix issue where the app does not work on macOS 15

### DIFF
--- a/ScrollableSimulator.xcodeproj/project.pbxproj
+++ b/ScrollableSimulator.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		4F8097EA2B6528A000192C7F /* ScrollableSimulatorLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8097E92B6528A000192C7F /* ScrollableSimulatorLauncher.swift */; };
 		4F8343EE2BD3C46E00DAAF4D /* Notification+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8343ED2BD3C46E00DAAF4D /* Notification+.swift */; };
 		4F8343F02BD3CFE600DAAF4D /* CombineSubjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8343EF2BD3CFE600DAAF4D /* CombineSubjects.swift */; };
+		4FD6AA4E2D806D7D00D4C858 /* Float32+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD6AA4D2D806D7A00D4C858 /* Float32+.swift */; };
 		4FE7384C2C9540F300EE18D1 /* ScrollableSimulatorControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE7384B2C9540F300EE18D1 /* ScrollableSimulatorControl.swift */; };
 		4FE7384E2C95411300EE18D1 /* ScrollableSimulatorLauncherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE7384D2C95411300EE18D1 /* ScrollableSimulatorLauncherError.swift */; };
 		4FEF63322B66452E00BA2032 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4FEF63312B66452E00BA2032 /* Main.storyboard */; };
@@ -47,6 +48,7 @@
 		4F8343E42BCB992500DAAF4D /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		4F8343ED2BD3C46E00DAAF4D /* Notification+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+.swift"; sourceTree = "<group>"; };
 		4F8343EF2BD3CFE600DAAF4D /* CombineSubjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineSubjects.swift; sourceTree = "<group>"; };
+		4FD6AA4D2D806D7A00D4C858 /* Float32+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Float32+.swift"; sourceTree = "<group>"; };
 		4FE7384B2C9540F300EE18D1 /* ScrollableSimulatorControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableSimulatorControl.swift; sourceTree = "<group>"; };
 		4FE7384D2C95411300EE18D1 /* ScrollableSimulatorLauncherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableSimulatorLauncherError.swift; sourceTree = "<group>"; };
 		4FEF63312B66452E00BA2032 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
@@ -132,6 +134,7 @@
 		4FEF632C2B66418100BA2032 /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				4FD6AA4D2D806D7A00D4C858 /* Float32+.swift */,
 				4F7744FD2B6631DF00741931 /* CGEvent+.swift */,
 				4FEF633F2B67F72F00BA2032 /* Logger.swift */,
 				4FEF63542B6BCE5500BA2032 /* Constants.swift */,
@@ -262,6 +265,7 @@
 				4FE7384C2C9540F300EE18D1 /* ScrollableSimulatorControl.swift in Sources */,
 				4F7744F62B65ED4E00741931 /* ScrollableSimulatorBehavior.swift in Sources */,
 				4FEF63402B67F72F00BA2032 /* Logger.swift in Sources */,
+				4FD6AA4E2D806D7D00D4C858 /* Float32+.swift in Sources */,
 				4FEF63572B6BDC8F00BA2032 /* LinkLabel.swift in Sources */,
 				4F8097DB2B65288E00192C7F /* AppDelegate.swift in Sources */,
 				4FEF63362B6647B300BA2032 /* Accessibility.swift in Sources */,

--- a/ScrollableSimulator/ScrollableSimulator/TrackpadScrollBehavior.swift
+++ b/ScrollableSimulator/ScrollableSimulator/TrackpadScrollBehavior.swift
@@ -40,12 +40,24 @@ class TrackpadScrollBehavior {
             x: additionalDraggedPosition.x + CGFloat(xScrollQuantity),
             y: additionalDraggedPosition.y + CGFloat(yScrollQuantity)
         )
-        mutableEvent.location = .init(
-            x: immutableEvent.location.x + additionalDraggedPosition.x,
-            y: immutableEvent.location.y + additionalDraggedPosition.y
-        )
-        copyAndStoreEvent(immutableEvent)
-        return Unmanaged.passUnretained(mutableEvent)
+        if #available(macOS 15.0, *) {
+            if let newEvent = newCGEvent(baseEvent: mutableEvent, addPoint: additionalDraggedPosition) {
+                copyAndStoreEvent(immutableEvent)
+                return Unmanaged.passRetained(newEvent)
+            } else {
+                assertionFailure("Failed to create new CGEvent")
+                copyAndStoreEvent(immutableEvent)
+                return Unmanaged.passUnretained(mutableEvent)
+            }
+        } else {
+            mutableEvent.location = .init(
+                x: immutableEvent.location.x + additionalDraggedPosition.x,
+                y: immutableEvent.location.y + additionalDraggedPosition.y
+            )
+
+            copyAndStoreEvent(immutableEvent)
+            return Unmanaged.passUnretained(mutableEvent)
+        }
     }
 
     private func isNonInertialScroll(lastEvent: CGEvent?) -> Bool {

--- a/ScrollableSimulator/Util/CGEvent+.swift
+++ b/ScrollableSimulator/Util/CGEvent+.swift
@@ -95,3 +95,96 @@ func getXScrollQuantity(from cfData: CFData) -> Int32 {
     let signedScrollQuantity = data.withUnsafeBytes { $0.load(as: Int32.self) }
     return signedScrollQuantity
 }
+
+@available(macOS 12.0, *)
+func newCGEvent(baseEvent: CGEvent, addPoint: CGPoint) -> CGEvent? {
+    let globalLocationAddress: [UInt8] = [0x00, 0x02, 0xc0, 0x38]
+    let localLocationAddress: [UInt8] = [0x00, 0x02, 0xc0, 0x39]
+
+    let mutableData = CFDataCreateMutableCopy(nil, 0, baseEvent.data)
+    guard let mutableDataRef = CFDataGetMutableBytePtr(mutableData) else { return nil }
+
+    // Update global location
+    guard let globalLocationOffset: Int = CFComputeNextOffset(bytes: mutableDataRef, count: CFDataGetLength(mutableData), target: globalLocationAddress) else {
+        return nil
+    }
+    let globalXBytes: [UInt8] = [
+        mutableDataRef[globalLocationOffset + 0],
+        mutableDataRef[globalLocationOffset + 1],
+        mutableDataRef[globalLocationOffset + 2],
+        mutableDataRef[globalLocationOffset + 3]
+    ]
+    let globalYBytes: [UInt8] = [
+        mutableDataRef[globalLocationOffset + 4],
+        mutableDataRef[globalLocationOffset + 5],
+        mutableDataRef[globalLocationOffset + 6],
+        mutableDataRef[globalLocationOffset + 7]
+    ]
+    let globalX = bytesToFloat(globalXBytes)
+    let globalY = bytesToFloat(globalYBytes)
+    let newGlobalX: Float32 = globalX + Float32(addPoint.x)
+    let newGlobalY: Float32 = globalY + Float32(addPoint.y)
+    let newGlobalXBytes = withUnsafeBytes(of: newGlobalX.bitPattern.bigEndian) { Array($0) }
+    let newGlobalYBytes = withUnsafeBytes(of: newGlobalY.bitPattern.bigEndian) { Array($0) }
+    mutableDataRef[globalLocationOffset + 0] = newGlobalXBytes[0]
+    mutableDataRef[globalLocationOffset + 1] = newGlobalXBytes[1]
+    mutableDataRef[globalLocationOffset + 2] = newGlobalXBytes[2]
+    mutableDataRef[globalLocationOffset + 3] = newGlobalXBytes[3]
+    mutableDataRef[globalLocationOffset + 4] = newGlobalYBytes[0]
+    mutableDataRef[globalLocationOffset + 5] = newGlobalYBytes[1]
+    mutableDataRef[globalLocationOffset + 6] = newGlobalYBytes[2]
+    mutableDataRef[globalLocationOffset + 7] = newGlobalYBytes[3]
+
+    // Update local location
+    guard let localLocationOffset: Int = CFComputeNextOffset(bytes: mutableDataRef, count: CFDataGetLength(mutableData), target: localLocationAddress) else {
+        return nil
+    }
+    let localXBytes: [UInt8] = [
+        mutableDataRef[localLocationOffset + 0],
+        mutableDataRef[localLocationOffset + 1],
+        mutableDataRef[localLocationOffset + 2],
+        mutableDataRef[localLocationOffset + 3]
+    ]
+    let localYBytes: [UInt8] = [
+        mutableDataRef[localLocationOffset + 4],
+        mutableDataRef[localLocationOffset + 5],
+        mutableDataRef[localLocationOffset + 6],
+        mutableDataRef[localLocationOffset + 7]
+    ]
+    let localX = bytesToFloat(localXBytes)
+    let localY = bytesToFloat(localYBytes)
+    let newLocalX: Float32 = localX + Float32(addPoint.x)
+    let newLocalY: Float32 = localY + Float32(addPoint.y)
+    let newLocalXBytes = withUnsafeBytes(of: newLocalX.bitPattern.bigEndian) { Array($0) }
+    let newLocalYBytes = withUnsafeBytes(of: newLocalY.bitPattern.bigEndian) { Array($0) }
+    mutableDataRef[localLocationOffset + 0] = newLocalXBytes[0]
+    mutableDataRef[localLocationOffset + 1] = newLocalXBytes[1]
+    mutableDataRef[localLocationOffset + 2] = newLocalXBytes[2]
+    mutableDataRef[localLocationOffset + 3] = newLocalXBytes[3]
+    mutableDataRef[localLocationOffset + 4] = newLocalYBytes[0]
+    mutableDataRef[localLocationOffset + 5] = newLocalYBytes[1]
+    mutableDataRef[localLocationOffset + 6] = newLocalYBytes[2]
+    mutableDataRef[localLocationOffset + 7] = newLocalYBytes[3]
+
+    #if DEBUG
+    print("globalX: \(globalX), globalY: \(globalY), localX: \(localX), localY: \(localY)")
+    print("newGlobalX: \(newGlobalX), newGlobalY: \(newGlobalY), newLocalX: \(newLocalX), newLocalY: \(newLocalY)")
+    print("---")
+    #endif
+
+    return CGEvent(withDataAllocator: kCFAllocatorDefault, data: mutableData)
+}
+
+private func CFComputeNextOffset(bytes: UnsafeMutablePointer<UInt8>, count: Int, target: [UInt8]) -> Int? {
+    for i in 0..<count {
+        for targetIndex in 0..<target.count {
+            if bytes[i + targetIndex] != target[targetIndex] {
+                break
+            }
+            if targetIndex == target.count - 1 {
+                return i + target.count
+            }
+        }
+    }
+    return nil
+}

--- a/ScrollableSimulator/Util/Float32+.swift
+++ b/ScrollableSimulator/Util/Float32+.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+func bytesToFloat(_ bytes: [UInt8]) -> Float {
+    if bytes.count >= 4 {
+        return Float(bitPattern: UInt32(bytes[0]) << 24 | UInt32(bytes[1]) << 16 | UInt32(bytes[2]) << 8 | UInt32(bytes[3]))
+    } else {
+        return 0
+    }
+}


### PR DESCRIPTION
# Fix issues with CGEvent handling and Simulator.app on macOS 15 (https://github.com/nhiroyasu/ScrollableSimulator/issues/4)

On macOS 15, CGEvent now has two types of mouse positions: the global position (relative to the entire screen) and the local position (relative to the active application).

It was confirmed that modifying the location of a CGEvent obtained via CGEvent.tapCreate caused the local coordinates to become (-1, -1).

This issue was resolved by modifying the bit data in CGEvent.data corresponding to the global and local coordinates, instead of directly changing CGEvent.location.

Additionally, starting with macOS 15, Simulator.app now only accepts drag events when the app is active.

Therefore, the event tap is now configured to activate only when Simulator.app is active.

